### PR TITLE
feat: fix footer on mobile.

### DIFF
--- a/index.html
+++ b/index.html
@@ -284,6 +284,16 @@
             .status::after {
                 right: -60px;
             }
+
+            .footer {
+                left: 0;
+                right: 0;
+                transform: none;
+                width: 100%;
+                text-align: center;
+                bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
+                padding: 0 1rem;
+            }
         }
 
         @media (max-width: 480px) {


### PR DESCRIPTION
This PR fixes the display of the footer to occupy the full with of the page but without getting too close of the `inset-buttom` of the viewport.

| Before    | After |
| -------- | ------- |
| <img width="321" height="473" alt="Screenshot 2025-08-09 at 11 23 22 PM" src="https://github.com/user-attachments/assets/51931634-79fb-4b3d-80bd-23868da96310" />  | <img width="339" height="471" alt="Screenshot 2025-08-09 at 11 24 31 PM" src="https://github.com/user-attachments/assets/fc7ab091-7f1e-459d-bf07-d3e2a9cdf839" />
  |